### PR TITLE
UI Expansion expansions

### DIFF
--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuBarter.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuBarter.lua
@@ -8,7 +8,7 @@ local common = require("UI Expansion.common")
 ----------------------------------------------------------------------------------------------------
 
 local barterFilters = common.createFilterInterface({
-	createSearchBar = true,
+	createSearchBar = common.config.useSearch,
 	createIcons = true,
 	createButtons = true,
 	useIcons = not common.config.useInventoryTextButtons,

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
@@ -42,7 +42,7 @@ local function onFilterChanged()
 end
 
 local contentsFilters = common.createFilterInterface({
-	createSearchBar = true,
+	createSearchBar = common.config.useSearch,
 	createIcons = true,
 	createButtons = true,
 	useIcons = not common.config.useInventoryTextButtons,

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventory.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventory.lua
@@ -9,7 +9,7 @@ local common = require("UI Expansion.common")
 ----------------------------------------------------------------------------------------------------
 
 local inventoryFilters = common.createFilterInterface({
-	createSearchBar = true,
+	createSearchBar = common.config.useSearch,
 	createIcons = true,
 	createButtons = true,
 	useIcons = not common.config.useInventoryTextButtons,

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventorySelect.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventorySelect.lua
@@ -8,7 +8,7 @@ local common = require("UI Expansion.common")
 ----------------------------------------------------------------------------------------------------
 
 local genericFilter = common.createFilterInterface({
-	createSearchBar = true,
+	createSearchBar = common.config.useSearch,
 	createIcons = true,
 	createButtons = false,
 	useIcons = true,
@@ -22,7 +22,7 @@ common.createStandardInventoryFilters(genericFilter)
 ----------------------------------------------------------------------------------------------------
 
 local genericFilterNoIcons = common.createFilterInterface({
-	createSearchBar = true,
+	createSearchBar = common.config.useSearch,
 	createIcons = false,
 	createButtons = false,
 	useIcons = false,

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuMagic.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuMagic.lua
@@ -74,7 +74,7 @@ local function searchSpellsList()
 end
 
 local magicFilters = common.createFilterInterface({
-	createSearchBar = true,
+	createSearchBar = common.config.useSearch,
 	createIcons = true,
 	createButtons = false,
 	useIcons = true,

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuRest.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuRest.lua
@@ -1,0 +1,21 @@
+local common = require("UI Expansion.common")
+
+local weekDays = {
+    "Sundas",
+    "Morndas",
+    "Tirdas",
+    "Middas",
+    "Turdas",
+    "Fredas",
+    "Loredas"
+}
+
+local function menuRestWait(e)
+    if (not common.config.displayWeekday) then
+        return
+    end
+    -- +3 offset, since the 16th of Last Seed (starting day) should be Thurdas.
+    local day = weekDays[(tes3.worldController.daysPassed.value + 3) % 7 + 1]
+    e.element.children[2].children[1].text =  day .. ", " .. e.element.children[2].children[1].text
+end
+event.register("uiActivated", menuRestWait, { filter = "MenuRestWait"})

--- a/User Interface Expansion/MWSE/mods/UI Expansion/common.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/common.lua
@@ -136,7 +136,7 @@ function filter_functions:setFiltersExact(params)
 		self.activeFilters = { params.filter }
 	end
 
-	if (self.searchText == nil) then
+	if (self.createSearchBar and self.searchText == nil) then
 		self.searchBlock.input.text = self.searchTextPlaceholder
 		self.searchBlock.input.color = self.searchTextPlaceholderColor
 	end
@@ -496,14 +496,14 @@ function common.createStandardInventoryFilters(filterInterface)
 			)
 		end,
 		tooltip = {
-			text = "Filter to tools and soulgems",
+			text = "Filter to tools and filled soulgems",
 			helpText = {
 				"Click to filter to:",
 				"- Apparatus",
 				"- Lockpicks",
 				"- Probes",
 				"- Repair Tools",
-				"- Soulgems",
+				"- Filled Soulgems",
 			},
 		},
 		icon = "icons/ui_exp/inventory_tools.tga",
@@ -527,6 +527,7 @@ function common.createStandardInventoryFilters(filterInterface)
 				"Click to filter to:",
 				"- Books",
 				"- Lights",
+				"- Empty Soulgems",
 				"- Misc. Items",
 			},
 		},

--- a/User Interface Expansion/MWSE/mods/UI Expansion/main.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/main.lua
@@ -1,17 +1,19 @@
 
 local common = require("UI Expansion.common")
 
-common.version = 1.0
+common.version = 1.1
 
 -- Configuration table.
 local defaultConfig = {
 	version = common.version,
 	showHelpText = true,
 	autoSelectInput = "Magic",
+	useSearch = true,
 	useInventoryTextButtons = true,
 	selectSpellsOnSearch = true,
 	autoFilterToTradable = true,
 	takeFilteredItems = true,
+	displayWeekday = true,
 	keybindClose = { 57 },
 	keybindTakeAll = { 29, 57 },
 	dialogueTopicSeenColor = "journal_finished_quest_color",
@@ -34,6 +36,7 @@ local defaultConfig = {
 		magic = true,
 		map = false,
 		options = true,
+		rest = true,
 		stat = true,
 	},
 }
@@ -115,6 +118,11 @@ local function onInitialized(e)
 		dofile("Data Files/MWSE/mods/UI Expansion/MenuOptions.lua")
 	else
 		mwse.log("[UI Expansion] Skipping module: options")
+	end
+	if (config.components.rest) then
+		dofile("Data Files/MWSE/mods/UI Expansion/MenuRest.lua")
+	else
+		mwse.log("[UI Expansion] Skipping module: rest")
 	end
 	if (config.components.stat) then
 		dofile("Data Files/MWSE/mods/UI Expansion/MenuStat.lua")

--- a/User Interface Expansion/MWSE/mods/UI Expansion/mcm.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/mcm.lua
@@ -131,6 +131,14 @@ function this.onCreate(container)
 		end
 	})
 
+	-- Toggle search bars.
+	createBooleanConfigPackage({
+		parent = mainPane,
+		label = "Use search bars?",
+		config = this.config,
+		key = "useSearch",
+	})
+
 	-- Toggle help text.
 	createBooleanConfigPackage({
 		parent = mainPane,
@@ -153,6 +161,14 @@ function this.onCreate(container)
 		label = "Replace Take All with Take Filtered in contents menu?",
 		config = this.config,
 		key = "takeFilteredItems",
+	})
+ 
+	-- Toggle displaying the weekday in the rest menu.
+	createBooleanConfigPackage({
+		parent = mainPane,
+		label = "Display weekday in rest menu?",
+		config = this.config,
+		key = "displayWeekday",
 	})
 
 	-- Credits:


### PR DESCRIPTION
Added weekday display on rest menu. This has an MCM option which might be overkill.

Added a 'use searchbar' MCM option, needs work. It seems to work as is, but you have to restart the game to toggle them on and off, which isn't ideal. Haven't looked into fixing that yet.

Clarified filter category tooltips re: soulgems.