### PR TITLE
Added common.allFilters table

### DIFF
--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuBarter.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuBarter.lua
@@ -8,6 +8,7 @@ local common = require("UI Expansion.common")
 ----------------------------------------------------------------------------------------------------
 
 local barterFilters = common.createFilterInterface({
+	filterName = "barter",
 	createSearchBar = true,
 	createIcons = true,
 	createButtons = true,
@@ -15,7 +16,6 @@ local barterFilters = common.createFilterInterface({
 	useSearch = common.config.useSearch,
 	onFilterChanged = tes3ui.updateBarterMenuTiles,
 })
-common.barterFilter = barterFilters
 
 common.createStandardInventoryFilters(barterFilters)
 

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuBarter.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuBarter.lua
@@ -35,14 +35,14 @@ local function onMenuBarterActivated(e)
 	barterFilters:createElements(buttonBlock)
 
 	-- Interface with the inventory filter to show the tradable tab.
-	common.inventoryFilter:setFilterHidden("tradable", false)
+	common.allFilters.inventory:setFilterHidden("tradable", false)
 	if (common.config.autoFilterToTradable) then
-		common.inventoryFilter:setFilter("tradable")
+		common.allFilters.inventory:setFilter("tradable")
 	end
 
 	-- Hide it again when this UI goes away.
 	buttonBlock:register("destroy", function(e)
-		common.inventoryFilter:setFilterHidden("tradable", true)
+		common.allFilters.inventory:setFilterHidden("tradable", true)
 	end)
 
 	-- Focus the filter search bar.

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
@@ -29,6 +29,9 @@ end
 local function onFilterChanged()
 	if (common.config.takeFilteredItems) then
 		local contentsMenu = tes3ui.findMenu(GUI_ID_MenuContents)
+		if (contentsMenu == nil) then
+			return
+		end
 		local takeAllButton = contentsMenu:findChild(GUI_ID_MenuContents_takeallbutton)
 		local contentsFilter = common.allFilters.contents
 		if (contentsFilter.searchText ~= nil or #contentsFilter.filtersOrdered ~= #contentsFilter.activeFilters) then

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
@@ -20,7 +20,7 @@ local function onSearchTextPreUpdate()
 		takeAllButton:triggerEvent("mouseClick")
 		return false
 	-- Space (when no text) closes.
-	elseif (common.contentsFilter:getSearchText() == nil and common.complexKeybindTest(common.config.keybindClose)) then
+	elseif (common.allFilters.contents:getSearchText() == nil and common.complexKeybindTest(common.config.keybindClose)) then
 		tes3ui.leaveMenuMode()
 		return false
 	end
@@ -30,7 +30,7 @@ local function onFilterChanged()
 	if (common.config.takeFilteredItems) then
 		local contentsMenu = tes3ui.findMenu(GUI_ID_MenuContents)
 		local takeAllButton = contentsMenu:findChild(GUI_ID_MenuContents_takeallbutton)
-		local contentsFilter = common.contentsFilter
+		local contentsFilter = common.allFilters.contents
 		if (contentsFilter.searchText ~= nil or #contentsFilter.filtersOrdered ~= #contentsFilter.activeFilters) then
 			takeAllButton.text = common.dictionary.takeFiltered
 		else
@@ -41,6 +41,7 @@ local function onFilterChanged()
 end
 
 local contentsFilters = common.createFilterInterface({
+	filterName = "contents",
 	createSearchBar = true,
 	createIcons = true,
 	createButtons = true,
@@ -49,7 +50,6 @@ local contentsFilters = common.createFilterInterface({
 	onFilterChanged = onFilterChanged,
 	onSearchTextPreUpdate = onSearchTextPreUpdate,
 })
-common.contentsFilter = contentsFilters
 
 common.createStandardInventoryFilters(contentsFilters)
 

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuContents.lua
@@ -12,7 +12,7 @@ local inputController = tes3.worldController.inputController
 -- Contents: Searching and filtering.
 ----------------------------------------------------------------------------------------------------
 
-local function onSearchTextPreUpdate()
+local function onKeyInput()
 	-- Ctrl+Space (default) takes all.
 	if (common.complexKeybindTest(common.config.keybindTakeAll)) then
 		local contentsMenu = tes3ui.findMenu(GUI_ID_MenuContents)
@@ -51,7 +51,6 @@ local contentsFilters = common.createFilterInterface({
 	useIcons = not common.config.useInventoryTextButtons,
 	useSearch = common.config.useSearch,
 	onFilterChanged = onFilterChanged,
-	onSearchTextPreUpdate = onSearchTextPreUpdate,
 })
 
 common.createStandardInventoryFilters(contentsFilters)
@@ -66,6 +65,13 @@ local function onMenuContentsActivated(e)
 	if (not e.newlyCreated) then
 		return
 	end
+
+	-- Register a key event for take all and container closing.
+	event.register("keyDown", onKeyInput)
+	event.register("menuExit", function (e)
+		event.unregister("keyDown", onKeyInput,
+		{ doOnce = true })
+	end)
 
 	-- Add a new block in the right place.
 	local contentsMenu = e.element

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventory.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventory.lua
@@ -12,6 +12,7 @@ local inputController = tes3.worldController.inputController
 ----------------------------------------------------------------------------------------------------
 
 local inventoryFilters = common.createFilterInterface({
+	filterName = "inventory",
 	createSearchBar = true,
 	createIcons = true,
 	createButtons = true,
@@ -19,7 +20,6 @@ local inventoryFilters = common.createFilterInterface({
 	useSearch = common.config.useSearch,
 	onFilterChanged = tes3ui.updateInventoryTiles,
 })
-common.inventoryFilter = inventoryFilters
 
 common.createStandardInventoryFilters(inventoryFilters)
 

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventorySelect.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuInventorySelect.lua
@@ -8,6 +8,7 @@ local common = require("UI Expansion.common")
 ----------------------------------------------------------------------------------------------------
 
 local genericFilter = common.createFilterInterface({
+	filterName = "inventorySelect",
 	createSearchBar = true,
 	createIcons = true,
 	createButtons = false,
@@ -23,6 +24,7 @@ common.createStandardInventoryFilters(genericFilter)
 ----------------------------------------------------------------------------------------------------
 
 local genericFilterNoIcons = common.createFilterInterface({
+	filterName = "inventorySelectNoIcons",
 	createSearchBar = true,
 	createIcons = false,
 	createButtons = false,

--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuMagic.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuMagic.lua
@@ -23,8 +23,8 @@ local function searchSubList(titleElement, listElement, isSpellFilter)
 	local matchCount = 0
 	for i, nameElement in ipairs(columnElements[1]) do
 		local filterObject = nameElement:getPropertyObject(isSpellFilter and "MagicMenu_Spell" or "MagicMenu_object")
-		local filter = common.magicFilter:triggerFilter({ text = filterObject.name, effects = (isSpellFilter and filterObject.effects or filterObject.enchantment.effects) })
-		
+		local filter = common.allFilters.magic:triggerFilter({ text = filterObject.name, effects = (isSpellFilter and filterObject.effects or filterObject.enchantment.effects) })
+
 		if (filter) then
 			matchCount = matchCount + 1
 		end
@@ -67,13 +67,14 @@ local function searchSpellsList()
 	-- Figure out dividers.
 	elements[3].visible = (hasMatchingPowers and hasMatchingSpells)
 	elements[6].visible = (hasMatchingSpells and hasMatchingItems or (not hasMatchingSpells and hasMatchingPowers and hasMatchingItems))
-	
-	if (common.magicFilter.searchText and common.config.selectSpellsOnSearch and firstSearchResult) then
+
+	if (common.allFilters.magic.searchText and common.config.selectSpellsOnSearch and firstSearchResult) then
 		firstSearchResult:triggerEvent("mouseClick")
 	end
 end
 
 local magicFilters = common.createFilterInterface({
+	filterName = "magic",
 	createSearchBar = true,
 	createIcons = true,
 	createButtons = false,
@@ -81,7 +82,6 @@ local magicFilters = common.createFilterInterface({
 	useSearch = common.config.useSearch,
 	onFilterChanged = searchSpellsList,
 })
-common.magicFilter = magicFilters
 
 local function getEffectsContainsSchool(effects, school)
 	for i = 1, #effects do

--- a/User Interface Expansion/MWSE/mods/UI Expansion/common.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/common.lua
@@ -541,6 +541,8 @@ function filter_functions:createElements(parent)
 	self:clearFilter()
 end
 
+common.allFilters = {}
+
 function common.createFilterInterface(params)
 	local filterData = {}
 
@@ -563,7 +565,16 @@ function common.createFilterInterface(params)
 	filterData.onFilterChanged = params.onFilterChanged
 	filterData.extraData = params.extraData
 
-	return setmetatable(filterData, filter_metatable)
+	local filterInterface = setmetatable(filterData, filter_metatable)
+	common.allFilters[params.filterName] = filterInterface
+	return filterInterface
+end
+
+function common.setAllFiltersVisibility(visible)
+	for key, filter in pairs(common.allFilters) do
+		filter:setSearchBarUsage(visible)
+		filter:clearFilter()
+	end
 end
 
 ----------------------------------------------------------------------------------------------------

--- a/User Interface Expansion/MWSE/mods/UI Expansion/mcm.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/mcm.lua
@@ -144,12 +144,7 @@ function this.onCreate(container)
 		config = this.config,
 		key = "useSearch",
 		onUpdate = function(e)
-			common.inventoryFilter:setSearchBarUsage(this.config.useSearch)
-			common.inventoryFilter:clearFilter()
-			common.magicFilter:setSearchBarUsage(this.config.useSearch)
-			common.magicFilter:clearFilter()
-			common.barterFilter:setSearchBarUsage(this.config.useSearch)
-			common.barterFilter:clearFilter()
+			common.setAllFiltersVisibility(this.config.useSearch)
 		end
 	})
 


### PR DESCRIPTION
This doesn't work very well. Inventory searchbar doesn't update for some reason, plenty of errors when turning MCM on and off. In general it works a lot worse than I thought.

This doesn't address takeall/close container stuff yet, so that still only works with searchbars enabled.