### PR TITLE
Change starting day to Fredas

### DIFF
--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuRest.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuRest.lua
@@ -63,8 +63,8 @@ local function menuRestWait(e)
 
 	-- Show day of week.
 	if (common.config.displayWeekday) then
-		-- +3 offset, since the 16th of Last Seed (starting day) should be Thurdas.
-		local day = common.i18n(string.format("restWait.weekDay.%d", (tes3.worldController.daysPassed.value + 3) % 7 + 1))
+		-- +4 offset, since the 16th of Last Seed (starting day) should be Fredas.
+		local day = common.i18n(string.format("restWait.weekDay.%d", (tes3.worldController.daysPassed.value + 4) % 7 + 1))
 		local userFriendlyTimestampElement = e.element.children[2].children[1]
 		userFriendlyTimestampElement.text = day .. ", " .. userFriendlyTimestampElement.text
 	end


### PR DESCRIPTION
4fc4a9eb18c9835dcc3115ef7a14382e6450d42c added week days, Judging by https://discord.com/channels/210394599246659585/266928025961103368/498652426954604544 this was supposed to be based on Oblivion's starting date, however it seems the sign got inverted (+3 instead of -3) leading to Thursday instead of Friday based on its Monday.

```
3e433-08-27 - 3e427-08-16 = 2201 days
7 + (1 - 2201 % 7) = 5 = Friday
```

By some miracle this also aligns with Daggerfall's 3e405-01-04 Thursday start. Either that or Beth cared about consistency with a game that has 30 days in every month.