### PR TITLE
Show resist mod in attribute tooltips.

### DIFF
--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuStat.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuStat.lua
@@ -72,7 +72,8 @@ local function OnMenuStatTooltip(source, effectFilter, idProperty, fortifyEffect
 				magnitudeLabel.borderLeft = 2
 				magnitudeLabel.absolutePosAlignX = 1.0
 			else
-				local magnitudeLabel = block:createLabel({ text = string.format("-%d", activeEffect.magnitude) })
+				local resistance = 100 - activeEffect.effectInstance.resistedPercent
+				local magnitudeLabel = block:createLabel({ text = string.format("-%d (%.1f%%)", activeEffect.magnitude, resistance) })
 				magnitudeLabel.color = GUI_Palette_Negative
 				magnitudeLabel.borderLeft = 2
 				magnitudeLabel.absolutePosAlignX = 1.0


### PR DESCRIPTION
When an active effect is adjusting an attribute, show the resistance percentage modifying the adjustment, in addition to the raw adjustment value.

This may be desirable, because the raw value can differ significantly from the actual change (in vanilla due to a birthsign like Elfborn, or when mods like [Putting the Will in Willpower](https://www.nexusmods.com/morrowind/mods/45742) are used). Seeing the adjustment percentage alongside the raw value can help the player determine why they are seeing the numbers they are seeing.