### PR TITLE
UI Expansion: Rational Names compat

### DIFF
--- a/User Interface Expansion/MWSE/mods/UI Expansion/MenuStat.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/MenuStat.lua
@@ -65,7 +65,15 @@ local function OnMenuStatTooltip(source, effectFilter, idProperty, fortifyEffect
 			icon.borderRight = 6
 
 			local magicInstance = activeEffect.instance
-			block:createLabel({ text = (magicInstance.item or magicInstance.source).name })
+
+			local labelText = ''
+			if magicInstance.item then
+				labelText = common.getDisplayName(magicInstance.item)
+			else
+				labelText = magicInstance.source.name
+			end 
+
+			block:createLabel({ text = labelText })
 			if (activeEffect.effectId == fortifyEffect) then
 				local magnitudeLabel = block:createLabel({ text = string.format("+%d", activeEffect.magnitude) })
 				magnitudeLabel.color = GUI_Palette_Positive

--- a/User Interface Expansion/MWSE/mods/UI Expansion/common.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/common.lua
@@ -1,4 +1,5 @@
 local common = {}
+local rationalNames = include("RationalNames.interop")
 
 ----------------------------------------------------------------------------------------------------
 -- Generic helper functions.
@@ -82,6 +83,16 @@ function common.isTextInputActive()
 	end
 
 	return focus.type == "textInput"
+end
+
+--- Get display name from Rational Names if it is enabled
+function common.getDisplayName(item)
+	if rationalNames == nil then
+		return item.name
+	end
+
+	local displayName = rationalNames.common.getDisplayName(item.id)
+	return displayName or item.name
 end
 
 ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
With Rational Names installed, attribute/skill tooltips show technical name of items contributing to the stat with the prefix added by RN. This PR implements using RN's interop to get item's display name if it's installed.

Before:
![image](https://github.com/user-attachments/assets/da3e91a5-29e3-45b6-a661-b41bcfe4193f)

After:
![image](https://github.com/user-attachments/assets/ebe78a30-0e4a-4fe4-a6f6-bbddd7590c57)
