### PR TITLE
UI Expansion: Buying Game compat

### DIFF
--- a/User Interface Expansion/MWSE/mods/UI Expansion/tooltip.lua
+++ b/User Interface Expansion/MWSE/mods/UI Expansion/tooltip.lua
@@ -295,6 +295,7 @@ local function replaceAlchemyTooltip(tooltip, alchemy)
 end
 
 local useMCPSoulgemValueRebalance = tes3.hasCodePatchFeature(tes3.codePatchFeature.soulgemValueRebalance)
+local buyingGameConfig = include('buyingGame.config')
 
 --- Early pass at updating tooltip information.
 --- @param e uiObjectTooltipEventData
@@ -387,7 +388,8 @@ local function extraTooltipEarly(e)
 
 			-- Value/Weight Ratio
 			local ratioBlock
-			if common.config.displayRatio and e.object.weight > 0 then
+			if common.config.displayRatio and e.object.weight > 0 and
+			(buyingGameConfig == nil or tes3.mobilePlayer.mercantile.current >= buyingGameConfig.knowsPrice ) then
 				local ratio = math.round(objectValue) / e.object.weight
 				ratioBlock = container:createBlock({ id = GUI_ID_TooltipIconRatioBlock })
 				ratioBlock.autoWidth = true


### PR DESCRIPTION
If [Buying Game](https://www.nexusmods.com/morrowind/mods/50574) is installed, only show value to weight ratio if player has mercantile skill high enough to see value.